### PR TITLE
feat: enable walk-only route suggestions using OTP endpoint

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -293,6 +293,7 @@ void main() {
       ],
       screens: [
         HomeScreenTrufiScreen(
+          walkRouteEndpoint: _otp150Endpoint,
           config: HomeScreenConfig(
             appName: _appName,
             deepLinkScheme: _deepLinkScheme,


### PR DESCRIPTION
## Summary
- Passes the OTP 1.5 endpoint to `HomeScreenTrufiScreen` so the route planner can fetch real street-level walking routes for short-distance trips
- Complements trufi-core #859 fix (trufi-association/trufi-core#864)

## Test plan
- [ ] Verify short-distance routes show a walk-only option with street-level geometry
- [ ] Verify long-distance routes are unaffected