### PR TITLE
Navigation in null state

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,0 +1,44 @@
+plugins {
+    id("com.android.application")
+    id("kotlin-android")
+    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    id("dev.flutter.flutter-gradle-plugin")
+}
+
+android {
+    namespace = "app.trufi.trufi"
+    compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+
+    defaultConfig {
+        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        applicationId = "app.trufi.trufi"
+        // You can update the following values to match your application needs.
+        // For more information, see: https://flutter.dev/to/review-gradle-config.
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
+    }
+
+    buildTypes {
+        release {
+            // TODO: Add your own signing config for the release build.
+            // Signing with the debug keys for now, so `flutter run --release` works.
+            signingConfig = signingConfigs.getByName("debug")
+        }
+    }
+}
+
+flutter {
+    source = "../.."
+}

--- a/android/app/src/main/kotlin/app/trufi/trufi/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/trufi/trufi/MainActivity.kt
@@ -1,0 +1,5 @@
+package app.trufi.trufi
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,0 +1,24 @@
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+val newBuildDir: Directory =
+    rootProject.layout.buildDirectory
+        .dir("../../build")
+        .get()
+rootProject.layout.buildDirectory.value(newBuildDir)
+
+subprojects {
+    val newSubprojectBuildDir: Directory = newBuildDir.dir(project.name)
+    project.layout.buildDirectory.value(newSubprojectBuildDir)
+}
+subprojects {
+    project.evaluationDependsOn(":app")
+}
+
+tasks.register<Delete>("clean") {
+    delete(rootProject.layout.buildDirectory)
+}

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -1,0 +1,26 @@
+pluginManagement {
+    val flutterSdkPath =
+        run {
+            val properties = java.util.Properties()
+            file("local.properties").inputStream().use { properties.load(it) }
+            val flutterSdkPath = properties.getProperty("flutter.sdk")
+            require(flutterSdkPath != null) { "flutter.sdk not set in local.properties" }
+            flutterSdkPath
+        }
+
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+plugins {
+    id("dev.flutter.flutter-plugin-loader") version "1.0.0"
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+}
+
+include(":app")

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,15 +62,9 @@ final List<IRoutingProvider> _routingEngines = [
       ),
     ),
   // Online routing via OTP 2.8.1
-  Otp28RoutingProvider(
-    endpoint: _otp281Endpoint,
-    displayName: 'OTP 2.8.1',
-  ),
+  Otp28RoutingProvider(endpoint: _otp281Endpoint, displayName: 'OTP 2.8.1'),
   // Online routing via OTP 1.5.0
-  Otp15RoutingProvider(
-    endpoint: _otp150Endpoint,
-    displayName: 'OTP 1.5.0',
-  ),
+  Otp15RoutingProvider(endpoint: _otp150Endpoint, displayName: 'OTP 1.5.0'),
 ];
 
 // Map engines
@@ -80,7 +74,8 @@ final List<ITrufiMapEngine> _mapEngines = [
     OfflineMapLibreEngine(
       engineId: 'offline_osm_liberty',
       nameBuilder: (ctx) => AppLocalizations.of(ctx)!.mapStandardOffline,
-      descriptionBuilder: (ctx) => AppLocalizations.of(ctx)!.mapStandardOfflineDesc,
+      descriptionBuilder: (ctx) =>
+          AppLocalizations.of(ctx)!.mapStandardOfflineDesc,
       config: OfflineMapConfig(
         mbtilesAsset: 'assets/offline/cochabamba.mbtiles',
         styleAsset: 'assets/offline/styles/osm-liberty/style.json',
@@ -107,7 +102,8 @@ final List<ITrufiMapEngine> _mapEngines = [
     OfflineMapLibreEngine(
       engineId: 'offline_osm_bright',
       nameBuilder: (ctx) => AppLocalizations.of(ctx)!.mapLightOffline,
-      descriptionBuilder: (ctx) => AppLocalizations.of(ctx)!.mapLightOfflineDesc,
+      descriptionBuilder: (ctx) =>
+          AppLocalizations.of(ctx)!.mapLightOfflineDesc,
       config: OfflineMapConfig(
         mbtilesAsset: 'assets/offline/cochabamba.mbtiles',
         styleAsset: 'assets/offline/styles/osm-bright/style.json',
@@ -164,7 +160,8 @@ final List<ITrufiMapEngine> _mapEngines = [
     OfflineMapLibreEngine(
       engineId: 'offline_fiord_color',
       nameBuilder: (ctx) => AppLocalizations.of(ctx)!.mapColorfulOffline,
-      descriptionBuilder: (ctx) => AppLocalizations.of(ctx)!.mapColorfulOfflineDesc,
+      descriptionBuilder: (ctx) =>
+          AppLocalizations.of(ctx)!.mapColorfulOfflineDesc,
       config: OfflineMapConfig(
         mbtilesAsset: 'assets/offline/cochabamba.mbtiles',
         styleAsset: 'assets/offline/styles/fiord-color/style.json',
@@ -201,7 +198,8 @@ final List<ITrufiMapEngine> _mapEngines = [
     engineId: 'osm_liberty',
     styleString: 'https://maps.trufi.app/styles/osm-liberty/style.json',
     nameBuilder: (ctx) => AppLocalizations.of(ctx)!.mapStandardOnline,
-    descriptionBuilder: (ctx) => AppLocalizations.of(ctx)!.mapStandardOnlineDesc,
+    descriptionBuilder: (ctx) =>
+        AppLocalizations.of(ctx)!.mapStandardOnlineDesc,
   ),
   MapLibreEngine(
     engineId: 'dark_matter',
@@ -213,7 +211,8 @@ final List<ITrufiMapEngine> _mapEngines = [
     engineId: 'fiord_color',
     styleString: 'https://maps.trufi.app/styles/fiord-color/style.json',
     nameBuilder: (ctx) => AppLocalizations.of(ctx)!.mapColorfulOnline,
-    descriptionBuilder: (ctx) => AppLocalizations.of(ctx)!.mapColorfulOnlineDesc,
+    descriptionBuilder: (ctx) =>
+        AppLocalizations.of(ctx)!.mapColorfulOnlineDesc,
   ),
 ];
 // ========================================
@@ -224,7 +223,10 @@ void main() {
       appName: _appName,
       deepLinkScheme: _deepLinkScheme,
       defaultLocale: const Locale('es'),
-      extraLocalizationsDelegates: [AppLocalizations.delegate],
+      extraLocalizationsDelegates: [
+        AppLocalizations.delegate,
+        NavigationLocalizations.delegate,
+      ],
       themeConfig: TrufiThemeConfig(
         theme: ThemeData(
           colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFFE1306C)),
@@ -249,11 +251,7 @@ void main() {
           icon: Icons.camera_alt_outlined,
           label: 'Instagram',
         ),
-        SocialMediaLink(
-          url: _whatsappUrl,
-          icon: Icons.chat,
-          label: 'WhatsApp',
-        ),
+        SocialMediaLink(url: _whatsappUrl, icon: Icons.chat, label: 'WhatsApp'),
       ],
       providers: [
         ChangeNotifierProvider(


### PR DESCRIPTION
When the list of available routes from point A to point B is retrieved, each card displays a button to start navigation mode. Internally, this action caused a null error that broke the app.

The problem was that a Provider used by the navigation screen was missing its instantiation.

This PR resolves the problem.