### PR TITLE
Null status error in route configuration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,8 @@ import 'package:trufi_core_routing/trufi_core_routing.dart'
         Otp28RoutingProvider,
         Otp15RoutingProvider,
         TrufiPlannerProvider,
-        TrufiPlannerConfig;
+        TrufiPlannerConfig,
+        RoutingLocalizations;
 import 'package:trufi_core_saved_places/trufi_core_saved_places.dart';
 import 'package:trufi_core_search_locations/trufi_core_search_locations.dart';
 import 'package:trufi_core_settings/trufi_core_settings.dart';
@@ -226,6 +227,7 @@ void main() {
       extraLocalizationsDelegates: [
         AppLocalizations.delegate,
         NavigationLocalizations.delegate,
+        RoutingLocalizations.delegate,
       ],
       themeConfig: TrufiThemeConfig(
         theme: ThemeData(


### PR DESCRIPTION
When accessing the route configuration screen with OTP provider 2.8.x, a null status exception is displayed. The problem is due to the absence of a 'RoutingLocalizations.delegate' instance in the main directory.

This PR resolves the issue.

![WhatsApp Image 2026-03-31 at 20 58 51](https://github.com/user-attachments/assets/bd79ca0a-a569-4452-af81-3aba8d40a08e)
