### PR TITLE
Add Cochabamba mbtiles builder tool

### DIFF
--- a/tools/mbtiles-bolivia-cochabamba/.env
+++ b/tools/mbtiles-bolivia-cochabamba/.env
@@ -1,0 +1,14 @@
+# City name (used for input/output filenames). Must match the file in
+# ../pbf-bolivia-cochabamba/out/${CITY_NAME}.osm.pbf
+CITY_NAME=cochabamba
+
+# Zoom levels. 14 is upstream's recommendation for transit apps.
+# 15 gives finer detail but ~4x file size.
+MAX_ZOOM=14
+MIN_ZOOM=0
+
+# Java heap for planetiler.
+JAVA_MEMORY=4g
+
+# Processing threads.
+THREADS=4

--- a/tools/mbtiles-bolivia-cochabamba/.gitignore
+++ b/tools/mbtiles-bolivia-cochabamba/.gitignore
@@ -1,0 +1,2 @@
+out/*
+!out/cochabamba.mbtiles

--- a/tools/mbtiles-bolivia-cochabamba/README.md
+++ b/tools/mbtiles-bolivia-cochabamba/README.md
@@ -1,0 +1,23 @@
+# mbtiles-bolivia-cochabamba
+
+Generates the Cochabamba `.mbtiles` (vector tiles for offline maps) using `openmaptiles/planetiler-openmaptiles`. Compose mirrors [`trufi-association/trufi-mbtiles-generator`](https://github.com/trufi-association/trufi-mbtiles-generator) with the input mount adjusted to read the sibling tool's PBF.
+
+## Run
+
+```bash
+docker compose up
+```
+
+Output: `./out/cochabamba.mbtiles` (committed). First run downloads Natural Earth + water polygon sources (~200 MB) which planetiler caches in the container.
+
+## Input
+
+Reads `../pbf-bolivia-cochabamba/out/cochabamba.osm.pbf` (mounted read-only). Generate it first with the sibling tool.
+
+## Cochabamba tweaks
+
+City-specific values live in [`.env`](.env): `CITY_NAME`, `MAX_ZOOM` (14 recommended for transit), `MIN_ZOOM`, `JAVA_MEMORY`, `THREADS`.
+
+## Pin
+
+The image tag is `openmaptiles/planetiler-openmaptiles:3.16` — the latest stable (non-SNAPSHOT) tag. Bump it when a newer stable tag ships.

--- a/tools/mbtiles-bolivia-cochabamba/docker-compose.yml
+++ b/tools/mbtiles-bolivia-cochabamba/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  generate:
+    image: openmaptiles/planetiler-openmaptiles:3.16
+    env_file:
+      - .env
+    volumes:
+      - ../pbf-bolivia-cochabamba/out:/in:ro
+      - ./out:/out
+    environment:
+      - JAVA_TOOL_OPTIONS=-Xmx${JAVA_MEMORY}
+    command: >-
+      --download
+      --force
+      --osm-path=/in/${CITY_NAME}.osm.pbf
+      --output=/out/${CITY_NAME}.mbtiles
+      --maxzoom=${MAX_ZOOM}
+      --minzoom=${MIN_ZOOM}
+      --threads=${THREADS}
+      --tmpdir=/tmp
+      --download_dir=/tmp/sources


### PR DESCRIPTION
## Summary

Adds `trufi-app/tools/mbtiles-bolivia-cochabamba/` — a reproducible builder for the Cochabamba `.mbtiles` (offline vector tiles).

- Wraps `openmaptiles/planetiler-openmaptiles:3.16` (pinned to the latest stable, non-SNAPSHOT tag).
- Compose mirrors the upstream [`trufi-mbtiles-generator`](https://github.com/trufi-association/trufi-mbtiles-generator) but mounts the input PBF read-only from the sibling `pbf-bolivia-cochabamba/out/` so the two tools chain without copying.
- Defaults: `MAX_ZOOM=14` (upstream's recommendation for transit), `MIN_ZOOM=0`, `JAVA_MEMORY=4g`, `THREADS=4`.
- Output `out/cochabamba.mbtiles` (~13.5 MB) is committed.

This PR does not touch `trufi-app/assets/`, `lib/`, or anything the running app consumes. Wiring the app to read from `tools/.../out/` is a later step.

## Notes

- The existing `assets/offline/cochabamba.mbtiles` (~25.8 MB) was likely generated with `MAX_ZOOM=15`. Bumping `.env` if you want parity is a one-line change (~4× larger output).
- `3.16.1-SNAPSHOT` (what `:latest` currently points to) and `3.16` produce byte-identical output for our input, so pinning to the stable tag is safe.

## Test plan

- [ ] `cd tools/mbtiles-bolivia-cochabamba && docker compose up` writes `out/cochabamba.mbtiles` and exits cleanly (~2-3 min on first run, slower if Natural Earth / water polygons need to be re-downloaded).
- [ ] The generated `.mbtiles` opens with `mbtiletools` / `tippecanoe-decode` or any MBTiles viewer.
- [ ] Re-running with the same input PBF produces a same-size output.
- [ ] Pre-existing `pbf-bolivia-cochabamba` and `gtfs-bolivia-cochabamba` tools still work.