### PR TITLE
feat: bump trufi-core to v5.12.0 and update Cochabamba fares to official Cercado tariff

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -324,27 +324,42 @@ void main() {
         FaresTrufiScreen(
           config: FaresConfig(
             currency: 'Bs.',
-            lastUpdated: DateTime(2024, 1, 15),
-            fares: [
-              const FareInfo(
-                transportType: 'Trufi',
-                icon: Icons.directions_bus,
-                regularFare: '2.00',
-                studentFare: '1.50',
-                seniorFare: '1.00',
-              ),
-              const FareInfo(
-                transportType: 'Micro',
-                icon: Icons.airport_shuttle,
-                regularFare: '1.50',
-                studentFare: '1.00',
-                seniorFare: '0.75',
-              ),
-              const FareInfo(
-                transportType: 'Minibus',
-                icon: Icons.directions_bus_filled,
-                regularFare: '2.50',
-                studentFare: '2.00',
+            lastUpdated: DateTime(2026, 5, 6),
+            additionalNotes:
+                'Tarifa provisional vigente para servicios urbanos dentro '
+                'del Cercado. El monto cobrado en algunos operadores puede '
+                'diferir.',
+            fares: const [
+              FareInfo(
+                title: 'Pasaje urbano (Cercado)',
+                icon: Icons.directions_bus_rounded,
+                primary: FareCategory(
+                  label: 'Usuarios en general',
+                  price: '3.00',
+                  icon: Icons.person_rounded,
+                ),
+                additional: [
+                  FareCategory(
+                    label: 'Estudiante sec./universitario',
+                    price: '2.00',
+                    icon: Icons.school_rounded,
+                  ),
+                  FareCategory(
+                    label: 'Estudiante de primaria',
+                    price: '1.00',
+                    icon: Icons.child_care_rounded,
+                  ),
+                  FareCategory(
+                    label: 'Adulto mayor',
+                    price: '2.50',
+                    icon: Icons.elderly_rounded,
+                  ),
+                  FareCategory(
+                    label: 'Persona con discapacidad',
+                    price: '2.50',
+                    icon: Icons.accessible_rounded,
+                  ),
+                ],
               ),
             ],
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1062,8 +1062,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_about"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1071,8 +1071,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_base_widgets"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1080,8 +1080,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_custom_material"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1089,8 +1089,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_fares"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1098,8 +1098,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_feedback"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1107,8 +1107,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_home_screen"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1116,8 +1116,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_interfaces"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1125,8 +1125,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_maps"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1134,8 +1134,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_navigation"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1143,8 +1143,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_planner"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1152,8 +1152,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_poi_layers"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1161,8 +1161,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_routing"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1170,8 +1170,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_routing_ui"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1179,8 +1179,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_saved_places"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1188,8 +1188,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_search_locations"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1197,8 +1197,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_settings"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1206,8 +1206,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_transport_list"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1215,8 +1215,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_ui"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1224,8 +1224,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_utils"
-      ref: "v5.11.0"
-      resolved-ref: "26afd651ffbaae614d9f9346130f260c30a6d4eb"
+      ref: "v5.12.0"
+      resolved-ref: "3f0a6cf05c267e45675319c170fa05fdf32018dd"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,77 +21,77 @@ dependencies:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_utils
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_about
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_transport_list
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_routing
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_saved_places
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_home_screen
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_search_locations
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_feedback
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_fares
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_settings
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_poi_layers
   latlong2: ^0.9.1
   maplibre: ^0.3.3+2
@@ -106,97 +106,97 @@ dependency_overrides:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_utils
   trufi_core_base_widgets:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_base_widgets
   trufi_core_custom_material:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_custom_material
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_routing
   trufi_core_routing_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_routing_ui
   trufi_core_planner:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_planner
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_search_locations
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/trufi_core_poi_layers
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_home_screen
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_saved_places
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_transport_list
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_fares
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_feedback
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_settings
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.11.0
+      ref: v5.12.0
       path: packages/screens/trufi_core_about
 
 flutter:


### PR DESCRIPTION
## Summary
- Bump every `trufi_core_*` git ref from `v5.11.0` to `v5.12.0` in both `dependencies:` and `dependency_overrides:` (refreshed `pubspec.lock`).
- Rewrite the `FaresTrufiScreen` wiring in `lib/main.dart` to the new arbitrary-categories schema introduced in [trufi-association/trufi-core#891](https://github.com/trufi-association/trufi-core/pull/891), and populate it with the official **Movilidad Urbana de Cochabamba** Cercado tariff:
  - General: **Bs. 3.00**
  - Estudiante sec./universitario: **Bs. 2.00**
  - Estudiante de primaria: **Bs. 1.00**
  - Adulto mayor: **Bs. 2.50**
  - Persona con discapacidad: **Bs. 2.50**
- Add a `additionalNotes` line clarifying the tariff applies only inside the Cercado and that the fare actually charged by some operators may differ.
- Bump `lastUpdated` to `2026-05-06`.

The previous wiring used three rows (Trufi / Micro / Minibus) with `regular`/`student`/`senior` slots that didn't fit the official municipal tariff (one tariff for all transit modes, five categories instead of three). With the new `FareCategory` schema we collapse to a single `Pasaje urbano (Cercado)` card that actually matches what Movilidad Urbana published.

Refs trufi-association/trufi-core#848

## Test plan
- [x] `flutter pub get` resolves cleanly with the new tag — no `path:` overrides remain in `pubspec.yaml` or `pubspec.lock` (`grep` returned 0).
- [x] `flutter analyze` — only the pre-existing `_shareUrl` `unused_element` warning, unchanged by this PR.
- [x] Runtime: ran on a Pixel 9a (Android 16, debug build) and navigated to **Tarifas** in the drawer. Card renders with the `Bs. 3.00` headline badge, four wrapping chips for student-secondary, student-primary, senior, and disability, the last-updated chip (`6/5/2026`), and the tip card with the Cercado disclaimer.