### PR TITLE
bump trufi-core to v5.14.0; routingTimeOverride + service hours indicator

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -232,6 +232,11 @@ void main() {
       appName: _appName,
       deepLinkScheme: _deepLinkScheme,
       defaultLocale: const Locale('es'),
+      // Cochabamba's bus network only runs roughly 06:00–22:00.
+      // Pinning the routing request to midday avoids "0 routes" when
+      // the user opens the app late at night, and the picker UI is
+      // hidden because the value is fixed.
+      routingTimeOverride: const TimeOfDay(hour: 12, minute: 0),
       extraLocalizationsDelegates: [AppLocalizations.delegate],
       themeConfig: TrufiThemeConfig(
         theme: ThemeData(
@@ -305,7 +310,6 @@ void main() {
             appName: _appName,
             deepLinkScheme: _deepLinkScheme,
             poiLayersManager: POILayersManager(assetsBasePath: 'assets/pois'),
-            showDepartureTimeChip: false,
           ),
           onStartNavigation: (context, itinerary, locationService) {
             NavigationScreen.showFromItinerary(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1062,8 +1062,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_about"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1071,8 +1071,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_base_widgets"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1080,8 +1080,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_custom_material"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1089,8 +1089,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_fares"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1098,8 +1098,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_feedback"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1107,8 +1107,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_home_screen"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1116,8 +1116,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_interfaces"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1125,8 +1125,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_maps"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1134,8 +1134,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_navigation"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1143,8 +1143,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_planner"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1152,8 +1152,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_poi_layers"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1161,8 +1161,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_routing"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1170,8 +1170,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_routing_ui"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1179,8 +1179,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_saved_places"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1188,8 +1188,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_search_locations"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1197,8 +1197,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_settings"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1206,8 +1206,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_transport_list"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1215,8 +1215,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_ui"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1224,8 +1224,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_utils"
-      ref: "v5.13.0"
-      resolved-ref: "95606b05ca92369f43e92fe6f65e0d7dc181c37c"
+      ref: "v5.14.0"
+      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,77 +21,77 @@ dependencies:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_utils
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_about
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_transport_list
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_routing
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_saved_places
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_home_screen
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_search_locations
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_feedback
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_fares
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_settings
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_poi_layers
   latlong2: ^0.9.1
   maplibre: ^0.3.3+2
@@ -106,97 +106,97 @@ dependency_overrides:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_utils
   trufi_core_base_widgets:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_base_widgets
   trufi_core_custom_material:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_custom_material
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_routing
   trufi_core_routing_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_routing_ui
   trufi_core_planner:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_planner
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_search_locations
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/trufi_core_poi_layers
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_home_screen
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_saved_places
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_transport_list
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_fares
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_feedback
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_settings
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.13.0
+      ref: v5.14.0
       path: packages/screens/trufi_core_about
 
 flutter:


### PR DESCRIPTION
## Summary

- Bump every `trufi_core_*` ref from `v5.13.0` to `v5.14.0` (both `dependencies` and `dependency_overrides`).
- Switch `HomeScreenConfig.showDepartureTimeChip: false` → `AppConfiguration.routingTimeOverride: TimeOfDay(hour: 12, minute: 0)`. The flag was removed in v5.14.0; this is the documented migration. Same end-result for the user (no chip, fixed mid-day request) plus the new behavior of suppressing absolute HH:mm labels that would otherwise be the override projected onto today.
- Pulls in the v5.14.0 service-hours indicator across the transit list, route detail, and itinerary plan legs (works for the local Trufi planner, OTP 1.5, OTP 2.4 and OTP 2.8 via `ServiceHoursLookup`), the agency line on local-planner legs, and OTP 1.5 intermediate stops.

Refs trufi-association/trufi-core#893.

## Test plan

- [x] `flutter pub get` clean against `v5.14.0` git ref
- [x] `flutter analyze` clean
- [x] Pixel 9a runtime: indicator + 7-day schedule + agency + intermediate stops verified on Local Planner, OTP 1.5 and OTP 2.8
- [x] Departure-time chip is hidden, no HH:mm leaks anywhere in the home screen, plans still resolve correctly