### PR TITLE
bump trufi-core to v5.14.1

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1062,8 +1062,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_about"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1071,8 +1071,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_base_widgets"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1080,8 +1080,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_custom_material"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1089,8 +1089,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_fares"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1098,8 +1098,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_feedback"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1107,8 +1107,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_home_screen"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1116,8 +1116,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_interfaces"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1125,8 +1125,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_maps"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1134,8 +1134,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_navigation"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1143,8 +1143,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_planner"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1152,8 +1152,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_poi_layers"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1161,8 +1161,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_routing"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1170,8 +1170,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_routing_ui"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1179,8 +1179,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_saved_places"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1188,8 +1188,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_search_locations"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1197,8 +1197,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_settings"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1206,8 +1206,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_transport_list"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1215,8 +1215,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_ui"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1224,8 +1224,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_utils"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.1"
+      resolved-ref: "1ae618aa4ed3d831d46295824c4d62b981a27069"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,77 +21,77 @@ dependencies:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_utils
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_about
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_transport_list
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_routing
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_saved_places
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_home_screen
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_search_locations
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_feedback
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_fares
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_settings
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_poi_layers
   latlong2: ^0.9.1
   maplibre: ^0.3.3+2
@@ -106,97 +106,97 @@ dependency_overrides:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_utils
   trufi_core_base_widgets:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_base_widgets
   trufi_core_custom_material:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_custom_material
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_routing
   trufi_core_routing_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_routing_ui
   trufi_core_planner:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_planner
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_search_locations
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/trufi_core_poi_layers
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_home_screen
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_saved_places
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_transport_list
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_fares
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_feedback
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_settings
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.1
       path: packages/screens/trufi_core_about
 
 flutter:


### PR DESCRIPTION
## Summary

Bumps `trufi_core_*` git refs from `v5.14.0` to `v5.14.1`.

`v5.14.1` fixes two issues from the 5.14.0 release that surfaced once the build was deployed to web / tested in landscape:

- **Wide-layout chip duplicate**: the departure-time chip is now also hidden in the wide layout (web / landscape phones / tablets) when `routingTimeOverride` is set. The mobile-layout guard added in 5.14.0 didn't cover the wide-layout copy of the chip.
- **`Leg.serviceHours` was not persisted**: the field was added in 5.14.0 but `toJson` / `fromJson` didn't carry it through, so the operating-hours indicator disappeared after a device rotation or app relaunch (the cubit reloaded the plan from disk without it). Now serialized as a compact `{daysOfWeek, startMinutes, endMinutes}` object.

Refs trufi-association/trufi-core#895.

## Test plan

- [x] `flutter pub get` clean against `v5.14.1` git ref
- [x] `flutter analyze` clean
- [x] Web build deployed to planner.trufi.app, verified in incognito: chip hidden in landscape, indicator visible after fresh fetch and survives reload
- [x] Android emulator (`store_phone`) in landscape: same — chip hidden, indicator visible