### PR TITLE
bump trufi-core to v5.14.2

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -58,7 +58,11 @@ final List<IRoutingProvider> _routingEngines = [
   if (kIsWeb)
     TrufiPlannerProvider(
       config: const TrufiPlannerConfig.remote(
-        serverUrl: '/api',
+        // Absolute URL on purpose: a relative `/api` works in
+        // production (same-origin behind the YARP gateway) but
+        // breaks `flutter run -d chrome` locally because it
+        // resolves to `localhost:8080/api`, which doesn't exist.
+        serverUrl: 'https://planner.trufi.app/api',
       ),
     ),
   // Online routing via OTP 2.8.1

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,22 +169,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.12"
-  device_info_plus:
-    dependency: transitive
-    description:
-      name: device_info_plus
-      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.1.2"
-  device_info_plus_platform_interface:
-    dependency: transitive
-    description:
-      name: device_info_plus_platform_interface
-      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.0.3"
   dio:
     dependency: transitive
     description:
@@ -1062,8 +1046,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_about"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1071,8 +1055,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_base_widgets"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1080,8 +1064,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_custom_material"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1089,8 +1073,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_fares"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1098,8 +1082,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_feedback"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1107,8 +1091,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_home_screen"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1116,8 +1100,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_interfaces"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1125,8 +1109,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_maps"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1134,8 +1118,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_navigation"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1143,8 +1127,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_planner"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1152,8 +1136,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_poi_layers"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1161,8 +1145,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_routing"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1170,8 +1154,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_routing_ui"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1179,8 +1163,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_saved_places"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1188,8 +1172,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_search_locations"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1197,8 +1181,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_settings"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1206,8 +1190,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_transport_list"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1215,8 +1199,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_ui"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1224,8 +1208,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_utils"
-      ref: "v5.14.0"
-      resolved-ref: f6d4159eb221e597541058de222babb330d639bb
+      ref: "v5.14.2"
+      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1413,14 +1397,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
-  win32_registry:
-    dependency: transitive
-    description:
-      name: win32_registry
-      sha256: "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.5"
   wkt_parser:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,77 +21,77 @@ dependencies:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_utils
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_about
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_transport_list
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_routing
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_saved_places
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_home_screen
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_search_locations
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_feedback
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_fares
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_settings
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_poi_layers
   latlong2: ^0.9.1
   maplibre: ^0.3.3+2
@@ -106,97 +106,97 @@ dependency_overrides:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_utils
   trufi_core_base_widgets:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_base_widgets
   trufi_core_custom_material:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_custom_material
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_routing
   trufi_core_routing_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_routing_ui
   trufi_core_planner:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_planner
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_search_locations
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/trufi_core_poi_layers
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_home_screen
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_saved_places
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_transport_list
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_fares
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_feedback
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_settings
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.0
+      ref: v5.14.2
       path: packages/screens/trufi_core_about
 
 flutter:


### PR DESCRIPTION
## Summary

Bump every `trufi_core_*` ref from `v5.14.0` to `v5.14.2`. v5.14.2 follows up the 5.14.0 feature release with three fixes that turned up while validating on web / landscape:

- Wide/web home layout now also hides the departure-time chip when `routingTimeOverride` is set (the 5.14.0 guard only covered the mobile layout).
- `Leg.serviceHours` is preserved through `toJson` / `fromJson`, so the operating-hours indicator no longer disappears after a device rotation or app relaunch.
- Drawer footer (and any other version-display surface) reads the app version from `package_info_plus` on every platform; the web build no longer prints the browser user-agent in place of the version.

Also flips the web build's `TrufiPlannerProvider.serverUrl` from the relative `/api` back to the absolute `https://planner.trufi.app/api`. The relative form is same-origin in production (so it worked once deployed) but resolves to `localhost:8080/api` under `flutter run -d chrome`, which doesn't exist.

Refs trufi-association/trufi-core#893, #895, #896.

## Test plan

- [x] `flutter pub get` clean against `v5.14.2`
- [x] `flutter analyze` clean
- [x] Web build deployed to planner.trufi.app, verified in incognito
- [x] Android emulator (`store_phone`) in landscape: chip hidden, indicator visible after fresh fetch and survives rotation back to portrait