### PR TITLE
chore: bump trufi-core to v5.15.0

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -276,6 +276,20 @@ void main() {
           label: 'WhatsApp',
         ),
       ],
+      overlayManager: OverlayManager(
+        managers: [
+          OnboardingManager(
+            overlayBuilder: (onComplete) =>
+                OnboardingSheet(onComplete: onComplete),
+          ),
+          PrivacyConsentManager(
+            overlayBuilder: (onAccept, onDecline) => PrivacyConsentSheet(
+              onAccept: onAccept,
+              onDecline: onDecline,
+            ),
+          ),
+        ],
+      ),
       providers: [
         ChangeNotifierProvider(
           create: (_) => MapEngineManager(
@@ -285,22 +299,6 @@ void main() {
         ),
         ChangeNotifierProvider(
           create: (_) => RoutingEngineManager(engines: _routingEngines),
-        ),
-        ChangeNotifierProvider(
-          create: (_) => OverlayManager(
-            managers: [
-              OnboardingManager(
-                overlayBuilder: (onComplete) =>
-                    OnboardingSheet(onComplete: onComplete),
-              ),
-              PrivacyConsentManager(
-                overlayBuilder: (onAccept, onDecline) => PrivacyConsentSheet(
-                  onAccept: onAccept,
-                  onDecline: onDecline,
-                ),
-              ),
-            ],
-          ),
         ),
         BlocProvider(
           create: (_) => SearchLocationsCubit(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1046,8 +1046,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_about"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1055,8 +1055,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_base_widgets"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1064,8 +1064,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_custom_material"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1073,8 +1073,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_fares"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1082,8 +1082,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_feedback"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1091,8 +1091,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_home_screen"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1100,8 +1100,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_interfaces"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1109,8 +1109,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_maps"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1118,8 +1118,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_navigation"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1127,8 +1127,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_planner"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1136,8 +1136,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_poi_layers"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1145,8 +1145,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_routing"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1154,8 +1154,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_routing_ui"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1163,8 +1163,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_saved_places"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1172,8 +1172,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_search_locations"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1181,8 +1181,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_settings"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1190,8 +1190,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_transport_list"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1199,8 +1199,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_ui"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1208,8 +1208,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_utils"
-      ref: "v5.14.2"
-      resolved-ref: ff847aff251c56e3c30da47a66b8f313f725db1a
+      ref: "v5.15.0"
+      resolved-ref: cddf6c20880c7d986a047093ba13869cfe79ff9e
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,77 +21,77 @@ dependencies:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_utils
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_about
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_transport_list
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_routing
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_saved_places
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_home_screen
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_search_locations
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_feedback
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_fares
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_settings
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_poi_layers
   latlong2: ^0.9.1
   maplibre: ^0.3.3+2
@@ -106,97 +106,97 @@ dependency_overrides:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_utils
   trufi_core_base_widgets:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_base_widgets
   trufi_core_custom_material:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_custom_material
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_routing
   trufi_core_routing_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_routing_ui
   trufi_core_planner:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_planner
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_search_locations
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/trufi_core_poi_layers
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_home_screen
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_saved_places
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_transport_list
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_fares
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_feedback
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_settings
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.14.2
+      ref: v5.15.0
       path: packages/screens/trufi_core_about
 
 flutter:


### PR DESCRIPTION
## Summary
- Bumps every `trufi_core_*` git dep from `v5.14.2` to `v5.15.0` (34 refs in `pubspec.yaml`).
- Migrates `main.dart` to the new `overlayManager:` field on `AppConfiguration` — required for the privacy consent toggle to keep working after the bump.

## What's in v5.15.0

- **#910** Privacy toggle reactivity fix + auto-registration of overlay managers as Providers. New `overlayManager` field on `AppConfiguration`; `OverlayService` now exposes a `providers` getter so the parent and every child manager (PrivacyConsentManager, OnboardingManager) are auto-registered into the root `MultiProvider`.
- **#911** Shared-route deep links plan the trip, not just fill the fields.

## Migration note

`AppOverlayManager` instances used to live inside `AppConfiguration.providers` wrapped in `ChangeNotifierProvider(create: ...)`. From v5.15.0 they belong in the dedicated `overlayManager:` field, which auto-wires `context.watch<PrivacyConsentManager>()` etc. Settings screen depends on this; without the migration the privacy toggle silently renders `SizedBox.shrink()`.

## Test plan
- [ ] `flutter pub get` resolves cleanly.
- [ ] `flutter analyze` clean (verified locally).
- [ ] Privacy toggle in Settings reflects state changes immediately.
- [ ] Toggling OFF → ON in Settings re-shows the original consent sheet (new behaviour from #910).
- [ ] Shared-route deep links auto-plan the trip on open (#911).