### PR TITLE
fix: pin Impeller to OpenGLES so the map stays responsive on Android 10

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -70,6 +70,16 @@
               <data android:scheme="trufiapp" android:host="route" />
             </intent-filter>
         </activity>
+        <!-- Pin Flutter's Impeller renderer to its OpenGLES backend.
+             User reports cluster on Android 10 devices whose legacy Vulkan
+             drivers freeze the MapLibre platform view (map stops responding
+             to pan/zoom) since the Flutter 3.44 upgrade made Impeller pick
+             Vulkan by default. The GLES path is verified to keep the map
+             fully interactive (API 29 and API 35). Remove once the affected
+             driver generation ages out or Flutter blocklists it. -->
+        <meta-data
+            android:name="io.flutter.embedding.android.ImpellerBackend"
+            android:value="opengles" />
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data


### PR DESCRIPTION
Mitigates trufi-association/trufi-core#925

## Investigation

The unresponsive-map reports cluster on **Android 10 (SDK 29)** and started "after the latest update" — which was the Flutter 3.44 upgrade. Since Flutter 3.27, the Impeller renderer is the default on Android and picks its **Vulkan** backend on any device that advertises Vulkan support. Android 10 hardware is exactly the generation with the shakiest Vulkan drivers, where Impeller + platform views (the MapLibre map) is known to misbehave.

Two findings support this:

1. On an Android 10 (API 29) emulator, the map works perfectly — but the log shows Impeller **falling back to OpenGLES** there (`Using the Impeller rendering backend (OpenGLES)`). Emulators never exercise the Vulkan path, which is why the freeze never reproduced in development while real devices in the field hit it.
2. With the backend pinned to OpenGLES via manifest, the map remains fully interactive on **both** API 29 and API 35 emulators (pan verified via screenshot diffing) — so the pin cannot regress devices that were fine.

## Change

One `meta-data` entry in the Android manifest:

```xml
<meta-data android:name="io.flutter.embedding.android.ImpellerBackend" android:value="opengles" />
```

This keeps Impeller (no deprecated renderer opt-outs) but routes every device through the GLES backend — the code path all development and testing already runs on. Perf impact for a map+UI app of this size is negligible.

## Honest caveat

Without one of the affected physical devices I can't *prove* the freeze disappears — no emulator can take the Vulkan path. The evidence chain (cohort = weak-Vulkan generation, regression window = Impeller default flip, emulator immunity = GLES fallback) all points here, the change is the standard Flutter knob for exactly this failure mode, and it's a one-line revert if field feedback says otherwise. Recommend shipping it in the next release and watching the Android 10 reviews.