### PR TITLE
fix: request up to 20 itineraries per search (trufi-core#952)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -288,7 +288,13 @@ void main() {
           ),
         ),
         ChangeNotifierProvider(
-          create: (_) => RoutingEngineManager(engines: _routingEngines),
+          create: (_) => RoutingEngineManager(
+            engines: _routingEngines,
+            // Cochabamba: request up to 20 itineraries per search so dense
+            // corridors show every trufi/micro option (trufi-core keeps its
+            // default of 5 for other cities). See trufi-core#923.
+            maxItineraries: 20,
+          ),
         ),
         BlocProvider(
           create: (_) => SearchLocationsCubit(


### PR DESCRIPTION
Fixes trufi-association/trufi-core#952.

trufi-core v5.19.0 already ships the app-configurable itinerary count (trufi-core#932: `RoutingEngineManager.maxItineraries`, default 5), but build 5.1.0+80 never set it — so the tester correctly saw 5 transit itineraries + 1 walk. This PR opts Cochabamba into **20**; other cities keep the core default.

Verified on an emulator against the same class of dense corridors the tester used (offline Cochabamba GTFS, 657 routes):

| Pair | before | after |
|---|---|---|
| Centro → Quillacollo | 5 (capped) | **20** |
| Centro → Av. América | 5 (capped) | 14 |
| Cala Cala → La Cancha | 5 (capped) | 18 |

Note for QA: 20 is a *maximum* — corridors with fewer unique direct lines return fewer, and the walk-only itinerary is added on top when origin/destination are ≤1.5 km apart.
