### PR TITLE
fix: make operator QR codes scannable, copyable and shareable (trufi-core#953)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -62,13 +62,24 @@
               <category android:name="android.intent.category.BROWSABLE" />
               <data android:scheme="geo" />
             </intent-filter>
-            <!-- Custom deep link scheme for route sharing -->
+            <!-- Custom deep link scheme for route sharing and in-app
+                 navigation (e.g. trufiapp://routes?operator=X opens the
+                 routes list filtered by operator). -->
             <intent-filter>
               <action android:name="android.intent.action.VIEW" />
               <category android:name="android.intent.category.DEFAULT" />
               <category android:name="android.intent.category.BROWSABLE" />
               <data android:scheme="trufiapp" android:host="route" />
+              <data android:scheme="trufiapp" android:host="routes" />
             </intent-filter>
+            <!-- Deep links are handled by the app_links plugin (DeepLinkService
+                 in trufi-core). Since Flutter 3.27 the engine's built-in deep
+                 linking is on by default and ALSO pushes the raw URI into
+                 go_router, clobbering the in-app navigation on warm links —
+                 this opts the engine out so app_links stays the only handler. -->
+            <meta-data
+              android:name="flutter_deeplinking_enabled"
+              android:value="false" />
         </activity>
         <!-- Pin Flutter's Impeller renderer to its OpenGLES backend.
              User reports cluster on Android 10 devices whose legacy Vulkan
@@ -85,6 +96,20 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- Required by the pasteboard plugin ("Copy QR" in the operator QR
+             dialog): on Android it writes the PNG to cacheDir and shares it
+             through a FileProvider with authority ${applicationId}.provider.
+             Without this declaration the copy fails with a PlatformException
+             ("Couldn't find meta-data for provider..."). -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -91,22 +91,6 @@
         <meta-data
             android:name="io.flutter.embedding.android.ImpellerBackend"
             android:value="opengles" />
-        <!-- Lets the pasteboard plugin share the rendered QR image with
-             the clipboard. Without it "Copy QR" throws (trufi-core#953). -->
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.provider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider_paths" />
-        </provider>
-        <!-- Don't delete the meta-data below.
-             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
-        <meta-data
-            android:name="flutterEmbedding"
-            android:value="2" />
         <!-- Required by the pasteboard plugin ("Copy QR" in the operator QR
              dialog): on Android it writes the PNG to cacheDir and shares it
              through a FileProvider with authority ${applicationId}.provider.
@@ -121,6 +105,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
+        <!-- Don't delete the meta-data below.
+             This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
+        <meta-data
+            android:name="flutterEmbedding"
+            android:value="2" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/res/xml/provider_paths.xml
+++ b/android/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Roots the pasteboard plugin's FileProvider can serve ("Copy QR").
+     cache-path is where the plugin actually writes the PNG (context.cacheDir);
+     external-path matches the plugin README's documented setup. -->
+<paths>
+    <cache-path name="cache" path="." />
+    <external-path name="external_files" path="." />
+</paths>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -22,6 +22,13 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<!-- Deep links are handled by the app_links plugin (DeepLinkService in
+	     trufi-core). Since Flutter 3.27 the engine's built-in deep linking
+	     is on by default and would also push the raw URI into the router,
+	     clobbering the in-app navigation — this opts the engine out.
+	     Mirrors flutter_deeplinking_enabled=false on Android. -->
+	<key>FlutterDeepLinkingEnabled</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -321,7 +321,14 @@ void main() {
           },
         ),
         SavedPlacesTrufiScreen(),
-        TransportListTrufiScreen(),
+        TransportListTrufiScreen(
+          // Operator QR codes / share links point at the web planner, so a
+          // phone without the app still lands somewhere useful and a phone
+          // with the app opens it directly via App Links (host-level
+          // intent-filter already covers /routes). Mirrors the home
+          // screen's shareBaseUrl above.
+          shareBaseUrl: _baseUrl,
+        ),
         FaresTrufiScreen(
           config: FaresConfig(
             currency: 'Bs.',


### PR DESCRIPTION
Fixes trufi-association/trufi-core#953.

All three reported failures had app-side causes; core v5.19.0's dialog itself is fine:

1. **QR led nowhere** — without `shareBaseUrl` the QR encoded `trufiapp://routes?...`; camera apps only act on http(s) payloads, and the manifest didn't even register the `routes` host. The QR now encodes `https://planner.trufi.app/routes?operator=X`, which any camera opens (App Links filter for the host already existed and is verified server-side), and `trufiapp://routes` is registered as fallback.
2. **"Couldn't copy the QR"** — real bug: the `pasteboard` plugin copies the PNG through a host-app `FileProvider` (`${applicationId}.provider`) that trufi-app never declared, so `Pasteboard.writeImage` threw a `PlatformException`. Added the provider + `provider_paths.xml` — including **`cache-path`**, since the plugin writes to `cacheDir` (its README only documents `external-path`; that alone still fails).
3. **Shared link arrived as plain text** — same root cause as (1): messengers don't linkify custom schemes. Sharing the https link fixes it.

Also opts out of the Flutter engine's built-in deep linking on Android **and** iOS (`flutter_deeplinking_enabled` / `FlutterDeepLinkingEnabled`), so `app_links`/`DeepLinkService` is the single handler and warm links stop clobbering in-app navigation (known Flutter ≥3.27 gotcha).

Verified on emulator: the rendered QR decodes (OpenCV) to `https://planner.trufi.app/routes?operator=Asociación+Mixta+de+Transporte+Huayñacota`, "Copy QR" places the image on the clipboard (system clipboard preview appears, no error), and opening the link shows the routes list filtered by that operator.

Companion docs PR in trufi-core documents the FileProvider requirement for other city apps.
