### PR TITLE
fix(qr): make the operator QR scannable and copyable

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -80,6 +80,17 @@
         <meta-data
             android:name="io.flutter.embedding.android.ImpellerBackend"
             android:value="opengles" />
+        <!-- Lets the pasteboard plugin share the rendered QR image with
+             the clipboard. Without it "Copy QR" throws (trufi-core#953). -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.provider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/provider_paths" />
+        </provider>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->
         <meta-data

--- a/android/app/src/main/res/xml/provider_paths.xml
+++ b/android/app/src/main/res/xml/provider_paths.xml
@@ -1,13 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Roots the pasteboard plugin may hand to the clipboard when copying the
-     operator QR image (trufi-core#953).
-     `cache-path` is the one that matters: the plugin writes the PNG to the
-     app's internal cache dir. The plugin README only documents
-     `external-path`, which leaves copying broken with
-     "Failed to find configured root that contains /data/data/<pkg>/cache/…". -->
+<!-- Root the pasteboard plugin needs to hand the operator QR image to the
+     clipboard (trufi-core#953). It writes the PNG to the app's internal
+     cache; the plugin README documents only `external-path`, which leaves
+     copying failing with "Failed to find configured root that contains
+     /data/data/<pkg>/cache/…". -->
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
     <cache-path name="cache" path="." />
-    <files-path name="files" path="." />
-    <external-path name="external_files" path="." />
-    <external-cache-path name="external_cache" path="." />
 </paths>

--- a/android/app/src/main/res/xml/provider_paths.xml
+++ b/android/app/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Roots the pasteboard plugin may hand to the clipboard when copying the
+     operator QR image (trufi-core#953).
+     `cache-path` is the one that matters: the plugin writes the PNG to the
+     app's internal cache dir. The plugin README only documents
+     `external-path`, which leaves copying broken with
+     "Failed to find configured root that contains /data/data/<pkg>/cache/…". -->
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="cache" path="." />
+    <files-path name="files" path="." />
+    <external-path name="external_files" path="." />
+    <external-cache-path name="external_cache" path="." />
+</paths>

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -321,7 +321,10 @@ void main() {
           },
         ),
         SavedPlacesTrufiScreen(),
-        TransportListTrufiScreen(),
+        // shareBaseUrl is what makes the operator QR encode an https app
+        // link; without it the code fell back to the trufiapp:// scheme,
+        // which a camera app cannot open (trufi-core#953).
+        TransportListTrufiScreen(shareBaseUrl: _baseUrl),
         FaresTrufiScreen(
           config: FaresConfig(
             currency: 'Bs.',


### PR DESCRIPTION
Fixes the two host-app halves of trufi-association/trufi-core#953 (operators print these QR codes and put them in vehicles).

## 1. The QR opened nothing when scanned

`TransportListTrufiScreen()` was constructed **without `shareBaseUrl`**, so the screen fell back to the app's custom scheme and encoded `trufiapp://routes?operator=…`. A camera app cannot resolve a custom scheme, so scanning a printed code did nothing.

Now it encodes `https://planner.trufi.app/routes?operator=…`, which opens the app when installed and the website otherwise.

## 2. "Copy QR" always failed

No `FileProvider` was declared, so `Pasteboard.writeImage` threw and the user got *"Couldn't copy the QR"*. The real exception (surfaced after fixing a swallowed `$e` in core) was:

```
PlatformException(Error, Failed to write image,
Failed to find configured root that contains
/data/data/app.trufi.navigator/cache/…png)
```

Worth knowing for other city apps: the pasteboard plugin's README only documents `<external-path>`, but the image is written to the app's **internal cache**, so `<cache-path>` is the root that actually matters. This PR declares cache, files and both external roots.

## Testing

Emulator, debug build: the sheet now shows the https link, scanning targets a real URL, and **Copy QR** completes with Android's clipboard preview showing the QR image — no error toast, nothing in logcat. Screenshots in the review comment.