### PR TITLE
Upgrade to trufi-core v5.22.2 (restores web builds)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1054,8 +1054,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_about"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1063,8 +1063,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_base_widgets"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1072,8 +1072,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_custom_material"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1081,8 +1081,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_fares"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1090,8 +1090,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_feedback"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1099,8 +1099,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_home_screen"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1108,8 +1108,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_interfaces"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1117,8 +1117,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_maps"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1126,8 +1126,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_navigation"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1135,8 +1135,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_planner"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1144,8 +1144,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_poi_layers"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1153,8 +1153,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_routing"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1162,8 +1162,8 @@ packages:
     dependency: "direct overridden"
     description:
       path: "packages/trufi_core_routing_ui"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1171,8 +1171,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_saved_places"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1180,8 +1180,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_search_locations"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1189,8 +1189,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_settings"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1198,8 +1198,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/screens/trufi_core_transport_list"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1207,8 +1207,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_ui"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"
@@ -1216,8 +1216,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/trufi_core_utils"
-      ref: "v5.22.1"
-      resolved-ref: "12c8f00e2c25c609be10026dea4e9c0b7ce48b1d"
+      ref: "v5.22.2"
+      resolved-ref: "18ab5f707b5001444f9e399c42c1141a69d02438"
       url: "https://github.com/trufi-association/trufi-core.git"
     source: git
     version: "1.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,77 +29,77 @@ dependencies:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_utils
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_about
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_transport_list
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_routing
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_saved_places
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_home_screen
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_search_locations
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_feedback
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_fares
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_settings
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_poi_layers
   latlong2: ^0.9.1
   maplibre_gl: ^0.26.2
@@ -123,97 +123,97 @@ dependency_overrides:
   trufi_core_interfaces:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_interfaces
   trufi_core_utils:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_utils
   trufi_core_base_widgets:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_base_widgets
   trufi_core_custom_material:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_custom_material
   trufi_core_maps:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_maps
   trufi_core_routing:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_routing
   trufi_core_routing_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_routing_ui
   trufi_core_planner:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_planner
   trufi_core_search_locations:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_search_locations
   trufi_core_ui:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_ui
   trufi_core_navigation:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_navigation
   trufi_core_poi_layers:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/trufi_core_poi_layers
   trufi_core_home_screen:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_home_screen
   trufi_core_saved_places:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_saved_places
   trufi_core_transport_list:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_transport_list
   trufi_core_fares:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_fares
   trufi_core_feedback:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_feedback
   trufi_core_settings:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_settings
   trufi_core_about:
     git:
       url: https://github.com/trufi-association/trufi-core.git
-      ref: v5.22.1
+      ref: v5.22.2
       path: packages/screens/trufi_core_about
 
 flutter:


### PR DESCRIPTION
[v5.22.2](https://github.com/trufi-association/trufi-core/releases/tag/v5.22.2) — hotfix for the dart2js-incompatible fingerprint hash that made v5.22.1 web-broken. Verified on this branch: `flutter build web --release` compiles and the bundle reports 5.3.0+82. Refs 34/34; lock resolved to the tag; no other changes.